### PR TITLE
Fix attribute parsing and add SkipTls and Authorization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Handles updating Marathon app instances to match the number of Mesos Agents or t
 ## Example env vars:
 
 ```
-DAEMONSET_DRYRUN=true 
-DAEMONSET_MESOSHOST=http://master.mesos:5050 
+DAEMONSET_DRYRUN=true
+DAEMONSET_MESOSHOST=http://master.mesos:5050
 DAEMONSET_MARATHONHOST=http://marathon.mesos:8080
 DAEMONSET_SERVERPORT=1234
 DAEMONSET_DEBUG=true
 DAEMONSET_UPDATEFREQUENCY=1m30s
+DAEMONSET_SKIPTLS=true
+DAEMONSET_AUTHORIZATION="Basic aBcDEfGhIJKlmNOpqR="
 ```
 
 update-frequency is the time in seconds between process runs.

--- a/config.go
+++ b/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	UpdateFrequency time.Duration `default:"5m0s"`
 	DryRun          bool          `default:"false"`
 	Debug           bool          `default:"false"`
+	SkipTls         bool          `default:"true"`
+	Authorization   string        `default:""`
 }
 
 // ConfigHost represents a host String.


### PR DESCRIPTION
Attributes parsing can fail if there are numbers if the attributes of a node (a rack number, size of ram or number of cpus for instance). In that the unmarshalling does not work. With interface{} the unmarshaller accepts any type in the map. It fixes the problem in my setup.

I also added two new options called SkipTls and Authorization for requesting information using an encrypted (with self-signed certificates) and protected Marathon API.